### PR TITLE
Use /usr/bin/env to invoke bash

### DIFF
--- a/mlb-coverage
+++ b/mlb-coverage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # mlb-coverage - compile and run an SML program defined in a MLB file
 #                using MLton and print a code coverage report

--- a/mlb-dependencies
+++ b/mlb-dependencies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # mlb-dependencies - read a MLB file defining an SML program and print
 # out a dependency list in Makefile format

--- a/mlb-expand
+++ b/mlb-expand
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # mlb-dependencies - read a MLB file defining an SML program and print
 # out a list of the files referred to by it and any subsidiary MLB files

--- a/polybuild
+++ b/polybuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # polybuild - compile a SML program defined in a MLB file using Poly/ML
 #

--- a/polyrepl
+++ b/polyrepl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # polyrepl - load a SML program defined in a MLB file into the Poly/ML
 # interactive environment

--- a/polyrun
+++ b/polyrun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # polyrun - run a SML program defined in a SML or MLB file using Poly/ML
 #

--- a/smlbuild-include.sh
+++ b/smlbuild-include.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Chris Cannam, 2015-2022. MIT licence
 

--- a/smlrepl
+++ b/smlrepl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # smlrepl - load a SML program defined in a MLB file into the SML/NJ
 # interactive environment

--- a/smlrun
+++ b/smlrun
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # smlrun - run a SML program defined in a SML or MLB file using SML/NJ
 #

--- a/with-mlb-dependencies
+++ b/with-mlb-dependencies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # with-mlb-dependencies - run a (presumed) compiler command, while also
 # dumping out a dependency file. Intended for Meson build integration.


### PR DESCRIPTION
Not all UNIX-based systems, or even all Linux systems, have bash in /bin.

However, having /usr/bin/env is significantly more common to the point where NixOS doesn't have /bin, /sbin or even /usr, *except* for the single `/usr/bin/env` file, precisely due to this issue.

PS: Thank you for these scripts, they are really, really useful!